### PR TITLE
fix guild desc url regex

### DIFF
--- a/src/pages/GuildPage/components/GuildCard.jsx
+++ b/src/pages/GuildPage/components/GuildCard.jsx
@@ -50,9 +50,9 @@ export function GuildCard() {
 			{hasDesc && 
 				<div className="w-100 mb-3">
 					{reactStringReplace(
-						guild.description, 
-						// https://stackoverflow.com/a/6041965
-						/(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/g,
+						guild.description,
+						// Simpler and working regex pattern for matching URLs
+						/(https?:\/\/[^\s/$.?#].[^\s]*)/g,
 						(match, i) => <ExternalLink href={match} key={i}>{match}</ExternalLink>
 					)}
 				</div> 


### PR DESCRIPTION
simpler and working regex for guild description urls

old: 
![image](https://github.com/user-attachments/assets/7e647368-0447-46e4-8d3f-9b844cc4cdac)


new: 
![image](https://github.com/user-attachments/assets/ea9088f7-6093-491a-9e4e-6861d1536f94)
